### PR TITLE
feat: add clean up functions to custom run-command(s) executors

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "esbuild-visualizer": "^0.3.1",
     "eslint": "^8.10.0",
     "eslint-config-prettier": "^8.5.0",
+    "execa": "5.1.1",
     "graphql-schema-linter": "^2.0.1",
     "husky": "^7.0.4",
     "jest": "^27.5.1",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "serverless-analyze-bundle-plugin": "^1.1.0",
     "serverless-esbuild": "^1.25.0",
     "serverless-offline": "^8.5.0",
+    "serverless-offline-sqs": "^6.0.0",
     "serverless-s3-remover": "^0.6.0",
     "ts-jest": "^27.1.3",
     "ts-loader": "^9.2.8",

--- a/serverless.common.yml
+++ b/serverless.common.yml
@@ -12,3 +12,11 @@ custom:
   esbuild:
     packager: yarn
     plugins: ../../esbuild-plugins.js
+  serverless-offline-sqs:
+    autoCreate: true # create queue if it does not exist
+    apiVersion: '2012-11-05'
+    endpoint: http://0.0.0.0:9324
+    region: us-east-1
+    accessKeyId: root
+    secretAccessKey: root
+    skipCacheInvalidation: false

--- a/services/background-jobs/docker-compose.yml
+++ b/services/background-jobs/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  sqs:
+    image: softwaremill/elasticmq:1.1.1
+    ports:
+      - 9324:9324
+      - 9325:9325

--- a/services/background-jobs/project.json
+++ b/services/background-jobs/project.json
@@ -8,7 +8,8 @@
       "options": {
         "cwd": "services/background-jobs",
         "color": true,
-        "command": "sls package"
+        "command": "sls package",
+        "exitCommand": "echo \"we out\""
       }
     },
     "serve": {
@@ -16,7 +17,9 @@
       "options": {
         "cwd": "services/background-jobs",
         "color": true,
-        "command": "sls offline start"
+        "parallel": true,
+        "command": "docker-compose up",
+        "exitCommand": "docker-compose stop"
       }
     },
     "deploy": {

--- a/services/background-jobs/serverless.yml
+++ b/services/background-jobs/serverless.yml
@@ -3,6 +3,7 @@ plugins:
   - serverless-s3-remover
   - serverless-esbuild
   - serverless-analyze-bundle-plugin
+  - serverless-offline-sqs
   - serverless-offline
 frameworkVersion: '3'
 useDotenv: true

--- a/tools/executors/workspace/command-schema.json
+++ b/tools/executors/workspace/command-schema.json
@@ -10,6 +10,14 @@
     "cwd": {
       "type": "string",
       "description": "The working directory to run the command in"
+    },
+    "exitCommand": {
+      "type": "string",
+      "description": "The command to run after the main command have finished"
+    },
+    "exitCommands": {
+      "type": "array",
+      "description": "The commands to run after the main command have finished"
     }
   },
   "required": ["command"]

--- a/tools/executors/workspace/commands-schema.json
+++ b/tools/executors/workspace/commands-schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "type": "object",
+  "cli": "nx",
+  "properties": {
+    "commands": {
+      "type": "array",
+      "description": "The commands to run"
+    },
+    "cwd": {
+      "type": "string",
+      "description": "The working directory to run the commands in"
+    },
+    "exitCommand": {
+      "type": "string",
+      "description": "The command to run after the main commands have finished"
+    },
+    "exitCommands": {
+      "type": "array",
+      "description": "The commands to run after the main commands have finished"
+    }
+  },
+  "required": ["commands"]
+}

--- a/tools/executors/workspace/executor.json
+++ b/tools/executors/workspace/executor.json
@@ -1,9 +1,14 @@
 {
   "executors": {
     "run-command": {
-      "implementation": "./impl",
-      "schema": "./schema.json",
+      "implementation": "./run-command/impl",
+      "schema": "./run-command/schema.json",
       "description": "Runs a command without capturing stdin/stdout/stderr"
+    },
+    "run-commands": {
+      "implementation": "./impl",
+      "schema": "./commands-schema.json",
+      "description": "Runs commands without capturing stdin/stdout/stderr"
     }
   }
 }

--- a/tools/executors/workspace/run-command/impl.js
+++ b/tools/executors/workspace/run-command/impl.js
@@ -1,0 +1,293 @@
+'use strict';
+var __assign =
+  (this && this.__assign) ||
+  function () {
+    __assign =
+      Object.assign ||
+      function (t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+          s = arguments[i];
+          for (var p in s)
+            if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+        }
+        return t;
+      };
+    return __assign.apply(this, arguments);
+  };
+var __awaiter =
+  (this && this.__awaiter) ||
+  function (thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P
+        ? value
+        : new P(function (resolve) {
+            resolve(value);
+          });
+    }
+    return new (P || (P = Promise))(function (resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function rejected(value) {
+        try {
+          step(generator['throw'](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done
+          ? resolve(result.value)
+          : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+var __generator =
+  (this && this.__generator) ||
+  function (thisArg, body) {
+    var _ = {
+        label: 0,
+        sent: function () {
+          if (t[0] & 1) throw t[1];
+          return t[1];
+        },
+        trys: [],
+        ops: [],
+      },
+      f,
+      y,
+      t,
+      g;
+    return (
+      (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+      typeof Symbol === 'function' &&
+        (g[Symbol.iterator] = function () {
+          return this;
+        }),
+      g
+    );
+    function verb(n) {
+      return function (v) {
+        return step([n, v]);
+      };
+    }
+    function step(op) {
+      if (f) throw new TypeError('Generator is already executing.');
+      while (_)
+        try {
+          if (
+            ((f = 1),
+            y &&
+              (t =
+                op[0] & 2
+                  ? y['return']
+                  : op[0]
+                  ? y['throw'] || ((t = y['return']) && t.call(y), 0)
+                  : y.next) &&
+              !(t = t.call(y, op[1])).done)
+          )
+            return t;
+          if (((y = 0), t)) op = [op[0] & 2, t.value];
+          switch (op[0]) {
+            case 0:
+            case 1:
+              t = op;
+              break;
+            case 4:
+              _.label++;
+              return { value: op[1], done: false };
+            case 5:
+              _.label++;
+              y = op[1];
+              op = [0];
+              continue;
+            case 7:
+              op = _.ops.pop();
+              _.trys.pop();
+              continue;
+            default:
+              if (
+                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                (op[0] === 6 || op[0] === 2)
+              ) {
+                _ = 0;
+                continue;
+              }
+              if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                _.label = op[1];
+                break;
+              }
+              if (op[0] === 6 && _.label < t[1]) {
+                _.label = t[1];
+                t = op;
+                break;
+              }
+              if (t && _.label < t[2]) {
+                _.label = t[2];
+                _.ops.push(op);
+                break;
+              }
+              if (t[2]) _.ops.pop();
+              _.trys.pop();
+              continue;
+          }
+          op = body.call(thisArg, _);
+        } catch (e) {
+          op = [6, e];
+          y = 0;
+        } finally {
+          f = t = 0;
+        }
+      if (op[0] & 5) throw op[1];
+      return { value: op[0] ? op[1] : void 0, done: true };
+    }
+  };
+exports.__esModule = true;
+var child_process_1 = require('child_process');
+var path = require('path');
+var npm_run_path_1 = require('npm-run-path');
+var LARGE_BUFFER = 1024 * 1000000;
+function loadEnvVars(path) {
+  return __awaiter(this, void 0, void 0, function () {
+    var result, _a;
+    return __generator(this, function (_b) {
+      switch (_b.label) {
+        case 0:
+          if (!path) return [3 /*break*/, 2];
+          return [
+            4 /*yield*/,
+            Promise.resolve().then(function () {
+              return require('dotenv');
+            }),
+          ];
+        case 1:
+          result = _b.sent().config({ path: path });
+          if (result.error) {
+            throw result.error;
+          }
+          return [3 /*break*/, 5];
+        case 2:
+          _b.trys.push([2, 4, , 5]);
+          return [
+            4 /*yield*/,
+            Promise.resolve().then(function () {
+              return require('dotenv');
+            }),
+          ];
+        case 3:
+          _b.sent().config();
+          return [3 /*break*/, 5];
+        case 4:
+          _a = _b.sent();
+          return [3 /*break*/, 5];
+        case 5:
+          return [2 /*return*/];
+      }
+    });
+  });
+}
+function buildExecutor(options, context) {
+  return __awaiter(this, void 0, void 0, function () {
+    var e_1;
+    return __generator(this, function (_a) {
+      switch (_a.label) {
+        case 0:
+          console.info('Executing workspace:run-command...');
+          return [4 /*yield*/, loadEnvVars(options.envFile)];
+        case 1:
+          _a.sent();
+          _a.label = 2;
+        case 2:
+          _a.trys.push([2, 4, , 5]);
+          process.stdin.resume();
+          process.on('SIGINT', function () {
+            console.log('noop on SIGINT');
+          });
+          process.on('SIGTERM', function () {
+            console.log('noop on SIGTERM');
+          });
+          console.log('getting ready to run '.concat(options.command));
+          return [
+            4 /*yield*/,
+            createProcess(
+              options.command,
+              calculateCwd(options.cwd, context),
+              options.color
+            ),
+          ];
+        case 3:
+          _a.sent();
+          return [2 /*return*/, { success: true }];
+        case 4:
+          e_1 = _a.sent();
+          if (process.env.NX_VERBOSE_LOGGING === 'true') {
+            console.error(e_1);
+          }
+          throw new Error(
+            'ERROR: Something went wrong in @nrwl/run-commands - '.concat(
+              e_1.message
+            )
+          );
+        case 5:
+          return [2 /*return*/];
+      }
+    });
+  });
+}
+exports['default'] = buildExecutor;
+function createProcess(command, cwd, color) {
+  return new Promise(function (res) {
+    var childProcess = (0, child_process_1.exec)(command, {
+      cwd: cwd,
+      env: processEnv(color),
+      maxBuffer: LARGE_BUFFER,
+    });
+    /**
+     * Ensure the child process is killed when the parent exits
+     */
+    var processExitListener = function (args) {
+      console.log('processExitListener', args);
+      childProcess.kill();
+    };
+    process.on('exit', function (args) {
+      console.log('exit handler', args);
+      childProcess.kill();
+    });
+    process.on('SIGTERM', function (args) {
+      console.log('SIGTERM handler', args);
+      // childProcess.kill();
+    });
+    childProcess.stdout.on('data', function (data) {
+      process.stdout.write(data);
+    });
+    childProcess.stderr.on('data', function (err) {
+      process.stderr.write(err);
+    });
+    childProcess.on('exit', function (code) {
+      process.stdout.write('Exit with code: '.concat(code));
+    });
+    childProcess.on('SIGINT', function () {
+      console.log("DON'T SIGINT");
+    });
+    childProcess.on('SIGTERM', function () {
+      console.log("DON'T SIGTERM");
+    });
+  });
+}
+function calculateCwd(cwd, context) {
+  if (!cwd) return context.root;
+  if (path.isAbsolute(cwd)) return cwd;
+  return path.join(context.root, cwd);
+}
+function processEnv(color) {
+  var env = __assign(__assign({}, process.env), (0, npm_run_path_1.env)());
+  if (color) {
+    env.FORCE_COLOR = ''.concat(color);
+  }
+  return env;
+}

--- a/tools/executors/workspace/run-command/impl.ts
+++ b/tools/executors/workspace/run-command/impl.ts
@@ -1,0 +1,130 @@
+import { ExecutorContext } from '@nrwl/devkit';
+import { exec } from 'child_process';
+import * as path from 'path';
+import { env as appendLocalEnv } from 'npm-run-path';
+
+const LARGE_BUFFER = 1024 * 1_000_000;
+
+async function loadEnvVars(path?: string) {
+  if (path) {
+    const result = (await import('dotenv')).config({ path });
+    if (result.error) {
+      throw result.error;
+    }
+  } else {
+    try {
+      (await import('dotenv')).config();
+    } catch {}
+  }
+}
+
+export interface RunCommandsBuilderOptions {
+  command: string;
+  color?: boolean;
+  cwd?: string;
+  args?: string;
+  envFile?: string;
+  outputPath?: string;
+  exitCommand?: string;
+}
+
+export default async function buildExecutor(
+  options: RunCommandsBuilderOptions,
+  context: ExecutorContext
+) {
+  console.info(`Executing workspace:run-command...`);
+  await loadEnvVars(options.envFile);
+
+  try {
+    process.on('SIGINT', () => {
+      console.log('noop on SIGINT');
+    });
+    process.on('SIGTERM', () => {
+      console.log('noop on SIGTERM');
+    });
+
+    console.log(`getting ready to run ${options.command}`);
+
+    await createProcess(
+      options.command,
+      calculateCwd(options.cwd, context),
+      options.color
+    );
+
+    return { success: true };
+  } catch (e) {
+    if (process.env.NX_VERBOSE_LOGGING === 'true') {
+      console.error(e);
+    }
+    throw new Error(
+      `ERROR: Something went wrong in @nrwl/run-commands - ${e.message}`
+    );
+  }
+}
+
+function createProcess(command: string, cwd: string, color: boolean) {
+  return new Promise((res) => {
+    const childProcess = exec(command, {
+      cwd,
+      env: processEnv(color),
+      maxBuffer: LARGE_BUFFER,
+      // stdio: [process.stdin, process.stdout, 'pipe'],
+    });
+
+    /**
+     * Ensure the child process is killed when the parent exits
+     */
+    const processExitListener = (args) => {
+      console.log('processExitListener', args);
+      childProcess.kill();
+    };
+    process.on('exit', (args) => {
+      console.log('exit handler', args);
+      childProcess.kill();
+    });
+    process.on('SIGTERM', (args) => {
+      console.log('SIGTERM handler', args);
+      // childProcess.kill();
+    });
+
+    childProcess.stdout.on('data', (data) => {
+      process.stdout.write(data);
+    });
+
+    childProcess.stderr.on('data', (err) => {
+      process.stderr.write(err);
+    });
+
+    childProcess.on('exit', (code) => {
+      process.stdout.write(`Exit with code: ${code}`);
+    });
+
+    childProcess.on('SIGINT', () => {
+      console.log("DON'T SIGINT");
+    });
+    childProcess.on('SIGTERM', () => {
+      console.log("DON'T SIGTERM");
+    });
+  });
+}
+
+function calculateCwd(
+  cwd: string | undefined,
+  context: ExecutorContext
+): string {
+  if (!cwd) return context.root;
+  if (path.isAbsolute(cwd)) return cwd;
+  return path.join(context.root, cwd);
+}
+
+function processEnv(color: boolean) {
+  const env = {
+    ...process.env,
+    ...appendLocalEnv(),
+  };
+
+  if (color) {
+    env.FORCE_COLOR = `${color}`;
+  }
+  return env;
+}

--- a/tools/executors/workspace/run-command/schema.json
+++ b/tools/executors/workspace/run-command/schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "type": "object",
+  "cli": "nx",
+  "properties": {
+    "color": {
+      "type": "boolean",
+      "description": "Use colors when showing output of command.",
+      "default": false
+    },
+    "command": {
+      "type": "string",
+      "description": "Command to run in child process."
+    },
+    "cwd": {
+      "type": "string",
+      "description": "Current working directory of the commands. If it's not specified the commands will run in the workspace root, if a relative path is specified the commands will run in that path relative to the workspace root and if it's an absolute path the commands will run in that path."
+    },
+    "exitCommand": {
+      "type": "string",
+      "description": "Command to run during process shutdown."
+    }
+  },
+  "required": ["command"]
+}

--- a/tools/executors/workspace/run-command/test.js
+++ b/tools/executors/workspace/run-command/test.js
@@ -1,0 +1,7 @@
+process.stdin.resume();
+process.on('SIGINT', () => {
+  console.log('noop on SIGINT');
+});
+process.on('SIGTERM', () => {
+  console.log('noop on SIGTERM');
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5088,7 +5088,7 @@ events@^3.2.0:
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
-execa@^5.0.0, execa@^5.1.1:
+execa@5.1.1, execa@^5.0.0, execa@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
   integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3185,6 +3185,21 @@ aws-sdk@^2.1076.0, aws-sdk@^2.1104.0:
     uuid "3.3.2"
     xml2js "0.4.19"
 
+aws-sdk@^2.970.0:
+  version "2.1106.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1106.0.tgz#5c536f57b484af56ca2e0b15fcf2e7d5846ffbd8"
+  integrity sha512-3dr0TTR2LI70ST8fa4IgXHpWdH4yv7FLnt9YEndwFQ8ar2EMCMpMU67wwCGBA72GUi0aOg4+lsLjGmCvIq3jug==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.16.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
 axios@^0.21.1:
   version "0.21.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
@@ -9116,6 +9131,15 @@ serverless-esbuild@^1.25.0:
     ramda "^0.27.0"
     semver "^7.3.5"
     string.prototype.matchall "^4.0.4"
+
+serverless-offline-sqs@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/serverless-offline-sqs/-/serverless-offline-sqs-6.0.0.tgz#e0af7242f6414b46ef7a5c0a24e705daad6d9d4f"
+  integrity sha512-/9UmJeOqfZ2IF18kMvBBE+7RF4hBi/zuNKbdy7p5ZEFaBFrXcqigJL0pEfd5HmOYhyV9foXqxRUC1I4d4Jht0w==
+  dependencies:
+    aws-sdk "^2.970.0"
+    lodash "^4.17.21"
+    p-queue "^6.6.2"
 
 serverless-offline@^8.5.0:
   version "8.5.0"


### PR DESCRIPTION
The goal of this change is to allow a dev to run `yarn serve background:jobs` (or equivalent) and have their docker container running ElasticMQ to stand up and upon killing the serverless-offline instance, stopping the docker container so the user does not have to do anything manually.

This draft is based on a different branch and has some excess work but I don't want to lose the ideas here. The `tools/executors/workspace/run-command/impl.js` v `tools/executors/workspace/run-command/test.js` really demonstrates the real issue here. To run the impl example, you can run `yarn serve background-jobs`. When you run `Ctrl + C` to send `SIGINT`, it kills the executor and you'll note that `SIGTERM` was sent. This is coming from somewhere in nx. I think it's [this killCurrentProcess function](https://github.com/nrwl/nx/blob/cb4126c4427ba9e5f2f71f681e2f9f1d08e764ce/packages/node/src/executors/node/node.impl.ts#L150-L165)  but I'm not super familiar with nx internals.

If you run `node tools/executors/workspace/run-command/test.js`, you'll notice that the `SIGINT` is properly captured in contrast. Without the ability to control the signal exits, I think this is going to be an impossible task to accomplish.