### PR TITLE
ci: optimize CI workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,7 @@ updates:
       - dustinsgoodman
     labels:
       - dependency
+    ignore:
+      # @nrwl deps should always be updated by running `npx nx migrate @nrwl/workspace`
+      - dependency-name: '@nrwl/*'
+      - depedency-name: 'nx'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,82 +8,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  setup:
+  build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [14.x]
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-      - name: Configure Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: '14.x'
-          cache: 'yarn'
-      - name: Install packages
-        run: yarn install --frozen-lockfile
-
-  service-generator:
-    runs-on: ubuntu-latest
-    needs: ['setup']
-    strategy:
-      matrix:
-        node-version: [14.x]
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-      - name: Configure Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: '14.x'
-          cache: 'yarn'
-      - name: Install packages
-        run: yarn install --frozen-lockfile
-      - name: Generate service
-        run: yarn workspace-generator service test-service
-
-  lib-generator:
-    runs-on: ubuntu-latest
-    needs: ['setup']
-    strategy:
-      matrix:
-        node-version: [14.x]
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-      - name: Configure Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: '14.x'
-          cache: 'yarn'
-      - name: Install packages
-        run: yarn install --frozen-lockfile
-      - name: Generate library
-        run: yarn workspace-generator lib test-lib
-
-  lint:
-    runs-on: ubuntu-latest
-    needs: ['setup']
-    strategy:
-      matrix:
-        node-version: [14.x]
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-      - name: Configure Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: '14.x'
-          cache: 'yarn'
-      - name: Install packages
-        run: yarn install --frozen-lockfile
-      - name: Linting
-        run: yarn lint:all
-
-  test:
-    runs-on: ubuntu-latest
-    needs: ['setup']
     strategy:
       matrix:
         node-version: [14.x]
@@ -112,24 +38,13 @@ jobs:
         env:
           IS_OFFLINE: ${{ secrets.IS_OFFLINE }}
           SLS_STAGE: ${{ secrets.SLS_STAGE }}
+      - name: Generate service
+        run: yarn workspace-generator service test-service
+      - name: Generate library
+        run: yarn workspace-generator lib test-lib
+      - name: Linting
+        run: yarn lint:all
       - name: Run tests
         run: yarn test:all
-
-  build:
-    runs-on: ubuntu-latest
-    needs: ['service-generator', 'lib-generator', 'lint', 'test']
-    strategy:
-      matrix:
-        node-version: [14.x]
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-      - name: Configure Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: '14.x'
-          cache: 'yarn'
-      - name: Install packages
-        run: yarn install --frozen-lockfile
       - name: Run sls package
         run: yarn build:all

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,13 +16,16 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+
       - name: Configure Node
         uses: actions/setup-node@v3
         with:
           node-version: '14.x'
           cache: 'yarn'
+
       - name: Install packages
         run: yarn install --frozen-lockfile
+
       - name: Create AWS profile
         uses: Fooji/create-aws-profile-action@v1
         with:
@@ -30,6 +33,7 @@ jobs:
           region: us-east-1
           key: xxx
           secret: xxx
+
       - name: Create .env file
         run: |
           touch .env
@@ -38,13 +42,18 @@ jobs:
         env:
           IS_OFFLINE: ${{ secrets.IS_OFFLINE }}
           SLS_STAGE: ${{ secrets.SLS_STAGE }}
+
       - name: Generate service
         run: yarn workspace-generator service test-service
+
       - name: Generate library
         run: yarn workspace-generator lib test-lib
+
       - name: Linting
         run: yarn lint:all
+
       - name: Run tests
         run: yarn test:all
+
       - name: Run sls package
         run: yarn build:all

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,84 @@ jobs:
       matrix:
         node-version: [14.x]
     steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Configure Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '14.x'
+      - name: Install packages
+        run: yarn install --frozen-lockfile
+
+  service-generator:
+    runs-on: ubuntu-latest
+    needs: ['setup']
+    strategy:
+      matrix:
+        node-version: [14.x]
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Configure Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '14.x'
+      - name: Install packages
+        run: yarn install --frozen-lockfile
+      - name: Generate service
+        run: yarn workspace-generator service test-service
+
+  lib-generator:
+    runs-on: ubuntu-latest
+    needs: ['setup']
+    strategy:
+      matrix:
+        node-version: [14.x]
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Configure Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '14.x'
+      - name: Install packages
+        run: yarn install --frozen-lockfile
+      - name: Generate library
+        run: yarn workspace-generator lib test-lib
+
+  lint:
+    runs-on: ubuntu-latest
+    needs: ['setup']
+    strategy:
+      matrix:
+        node-version: [14.x]
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Configure Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '14.x'
+      - name: Install packages
+        run: yarn install --frozen-lockfile
+      - name: Linting
+        run: yarn lint:all
+
+  test:
+    runs-on: ubuntu-latest
+    needs: ['setup']
+    strategy:
+      matrix:
+        node-version: [14.x]
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Configure Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '14.x'
+      - name: Install packages
+        run: yarn install --frozen-lockfile
       - name: Create AWS profile
         uses: Fooji/create-aws-profile-action@v1
         with:
@@ -29,52 +107,6 @@ jobs:
         env:
           IS_OFFLINE: ${{ secrets.IS_OFFLINE }}
           SLS_STAGE: ${{ secrets.SLS_STAGE }}
-      - name: Checkout Repo
-        uses: actions/checkout@v2
-      - name: Configure Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: '14.x'
-      - name: Install packages
-        run: yarn install --frozen-lockfile
-
-  service-generator:
-    runs-on: ubuntu-latest
-    needs: ['setup']
-    strategy:
-      matrix:
-        node-version: [14.x]
-    steps:
-      - name: Generate service
-        run: yarn workspace-generator service test-service
-
-  lib-generator:
-    runs-on: ubuntu-latest
-    needs: ['setup']
-    strategy:
-      matrix:
-        node-version: [14.x]
-    steps:
-      - name: Generate library
-        run: yarn workspace-generator lib test-lib
-
-  lint:
-    runs-on: ubuntu-latest
-    needs: ['setup']
-    strategy:
-      matrix:
-        node-version: [14.x]
-    steps:
-      - name: Linting
-        run: yarn lint:all
-
-  test:
-    runs-on: ubuntu-latest
-    needs: ['setup']
-    strategy:
-      matrix:
-        node-version: [14.x]
-    steps:
       - name: Run tests
         run: yarn test:all
 
@@ -85,5 +117,13 @@ jobs:
       matrix:
         node-version: [14.x]
     steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Configure Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '14.x'
+      - name: Install packages
+        run: yarn install --frozen-lockfile
       - name: Run sls package
         run: yarn build:all

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '14.x'
+          cache: 'yarn'
       - name: Install packages
         run: yarn install --frozen-lockfile
 
@@ -36,6 +37,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '14.x'
+          cache: 'yarn'
       - name: Install packages
         run: yarn install --frozen-lockfile
       - name: Generate service
@@ -54,6 +56,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '14.x'
+          cache: 'yarn'
       - name: Install packages
         run: yarn install --frozen-lockfile
       - name: Generate library
@@ -72,6 +75,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '14.x'
+          cache: 'yarn'
       - name: Install packages
         run: yarn install --frozen-lockfile
       - name: Linting
@@ -90,6 +94,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '14.x'
+          cache: 'yarn'
       - name: Install packages
         run: yarn install --frozen-lockfile
       - name: Create AWS profile
@@ -123,6 +128,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '14.x'
+          cache: 'yarn'
       - name: Install packages
         run: yarn install --frozen-lockfile
       - name: Run sls package

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,26 +1,18 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
   push:
     branches: [main]
   pull_request:
     branches: [main]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
+  setup:
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
+    strategy:
+      matrix:
+        node-version: [14.x]
     steps:
       - name: Create AWS profile
         uses: Fooji/create-aws-profile-action@v1
@@ -29,25 +21,6 @@ jobs:
           region: us-east-1
           key: xxx
           secret: xxx
-
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14.x'
-
-      - name: Install packages
-        run: yarn install --frozen-lockfile
-
-      - name: Generate service
-        run: yarn workspace-generator service test-service
-
-      - name: Generate library
-        run: yarn workspace-generator lib test-lib
-
-      - name: Linting
-        run: yarn lint:all
-
       - name: Create .env file
         run: |
           touch .env
@@ -56,9 +29,61 @@ jobs:
         env:
           IS_OFFLINE: ${{ secrets.IS_OFFLINE }}
           SLS_STAGE: ${{ secrets.SLS_STAGE }}
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Configure Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+      - name: Install packages
+        run: yarn install --frozen-lockfile
 
+  service-generator:
+    runs-on: ubuntu-latest
+    needs: ['setup']
+    strategy:
+      matrix:
+        node-version: [14.x]
+    steps:
+      - name: Generate service
+        run: yarn workspace-generator service test-service
+
+  lib-generator:
+    runs-on: ubuntu-latest
+    needs: ['setup']
+    strategy:
+      matrix:
+        node-version: [14.x]
+    steps:
+      - name: Generate library
+        run: yarn workspace-generator lib test-lib
+
+  lint:
+    runs-on: ubuntu-latest
+    needs: ['setup']
+    strategy:
+      matrix:
+        node-version: [14.x]
+    steps:
+      - name: Linting
+        run: yarn lint:all
+
+  test:
+    runs-on: ubuntu-latest
+    needs: ['setup']
+    strategy:
+      matrix:
+        node-version: [14.x]
+    steps:
       - name: Run tests
         run: yarn test:all
 
+  build:
+    runs-on: ubuntu-latest
+    needs: ['service-generator', 'lib-generator', 'lint', 'test']
+    strategy:
+      matrix:
+        node-version: [14.x]
+    steps:
       - name: Run sls package
         run: yarn build:all


### PR DESCRIPTION
- [ ] ~parallelize steps~
- [ ] ~create all setup upfront~

Turns out parallel builds were actually slower as seen in https://github.com/dustinsgoodman/serverless-microservices-graphql-template/actions/runs/2142660098. So instead, I've just added caching and changed some ordering. I also fixed some dependabot settings to avoid nx workspace updates happening since it requires the `nx migrate` command.

Closes #63 