### PR TITLE
chore: update default config settings for serverless

### DIFF
--- a/services/background-jobs/serverless.ts
+++ b/services/background-jobs/serverless.ts
@@ -24,6 +24,8 @@ const serverlessConfiguration: Serverless = {
     runtime: 'nodejs14.x',
     stage: "${opt:stage, 'dev'}",
     region: "${opt:region, 'us-east-1'}",
+    memorySize: 512, // default: 1024MB
+    timeout: 900, // 15 minutes - this is the maximum allowed by Lambda
     environment: {
       REGION: '${aws:region}',
       SLS_STAGE: '${sls:stage}',

--- a/services/example-service/serverless.ts
+++ b/services/example-service/serverless.ts
@@ -23,6 +23,8 @@ const serverlessConfiguration: Serverless = {
     runtime: 'nodejs14.x',
     stage: "${opt:stage, 'dev'}",
     region: "${opt:region, 'us-east-1'}",
+    memorySize: 512, // default: 1024MB
+    timeout: 29, // default: max allowable for Gateway
     environment: {
       REGION: '${aws:region}',
       SLS_STAGE: '${sls:stage}',

--- a/services/public-api/serverless.ts
+++ b/services/public-api/serverless.ts
@@ -23,6 +23,8 @@ const serverlessConfiguration: Serverless = {
     runtime: 'nodejs14.x',
     stage: "${opt:stage, 'dev'}",
     region: "${opt:region, 'us-east-1'}",
+    memorySize: 512, // default: 1024MB
+    timeout: 29, // default: max allowable for Gateway
     httpApi: {
       // TODO: update to be more restrictive for real apps: https://www.serverless.com/framework/docs/providers/aws/events/http-api/#cors-setup
       cors: true,

--- a/tools/executors/workspace/impl.js
+++ b/tools/executors/workspace/impl.js
@@ -387,7 +387,7 @@ function createProcess(command, readyWhen, color, cwd) {
 function createSyncProcess(command, color, cwd) {
   (0, child_process_1.execSync)(command, {
     env: processEnv(color),
-    stdio: [process.stdin, process.stdout, 'pipe'],
+    stdio: [process.stdin, process.stdout, process.stderr],
     maxBuffer: exports.LARGE_BUFFER,
     cwd: cwd,
   });

--- a/tools/executors/workspace/impl.ts
+++ b/tools/executors/workspace/impl.ts
@@ -212,7 +212,7 @@ function createProcess(
 function createSyncProcess(command: string, color: boolean, cwd: string) {
   execSync(command, {
     env: processEnv(color),
-    stdio: [process.stdin, process.stdout, 'pipe'],
+    stdio: [process.stdin, process.stdout, process.stderr],
     maxBuffer: LARGE_BUFFER,
     cwd,
   });

--- a/tools/generators/service/files/serverless.ts__tmpl__
+++ b/tools/generators/service/files/serverless.ts__tmpl__
@@ -23,6 +23,8 @@ const serverlessConfiguration: Serverless = {
     runtime: 'nodejs14.x',
     stage: "${opt:stage, 'dev'}",
     region: "${opt:region, 'us-east-1'}",
+    memorySize: 512, // default: 1024MB
+    timeout: 29, // default: max allowable for Gateway
     environment: {
       REGION: '${aws:region}',
       SLS_STAGE: '${sls:stage}',


### PR DESCRIPTION
By default, the serverless framework sets Lambda execution to have 1024MB (1GB) of memory and a 6s timeout. The memory is overkill in most situations and the timeout is too low for longer running functions. Additionally, API Gateway has a timeout of 30s. This change will reduce the default lambda size to 512MB and increase the timeout to 29s for standard API services. The background-jobs service will have a 15min (900s) timeout as those functions naturally run longer. Overall, this should help reduce costs and help with timeout issues. 😄 

Thanks to @jtomchak for reminding me to do this!

Closes #83 