### PR TITLE
feat: add serverless-domain-manager config helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "prettier": "2.7.1",
     "serverless": "^3.21.0",
     "serverless-analyze-bundle-plugin": "^1.2.0",
+    "serverless-domain-manager": "^6.0.4",
     "serverless-esbuild": "^1.32.5",
     "serverless-offline": "^8.8.1",
     "serverless-offline-sqs": "^6.0.0",

--- a/serverless.common.ts
+++ b/serverless.common.ts
@@ -25,25 +25,52 @@ export const PORTS: PortConfig = {
 };
 
 export const getCustomConfig = (
-  serviceName: Service
-): Serverless['custom'] => ({
-  'serverless-offline': {
-    httpPort: PORTS[serviceName].httpPort,
-    lambdaPort: PORTS[serviceName].lambdaPort,
-  },
-  esbuild: {
-    packager: 'yarn',
-    bundle: true,
-    minify: true,
-    sourcemap: true,
-  },
-  'serverless-offline-sqs': {
-    autoCreate: true,
-    apiVersion: '2012-11-05',
-    endpoint: 'http://0.0.0.0:9324',
-    region: 'us-east-1',
-    accessKeyId: 'root',
-    secretAccessKey: 'root',
-    skipCacheInvalidation: false,
-  },
-});
+  serviceName: Service,
+  customSettings: {
+    domain: {
+      name: string;
+      stage: string;
+      basePath: string;
+    };
+  } = {
+    domain: {
+      name: '',
+      stage: 'prod',
+      basePath: 'api',
+    },
+  }
+): Serverless['custom'] => {
+  return {
+    'serverless-offline': {
+      httpPort: PORTS[serviceName].httpPort,
+      lambdaPort: PORTS[serviceName].lambdaPort,
+    },
+    esbuild: {
+      packager: 'yarn',
+      bundle: true,
+      minify: true,
+      sourcemap: true,
+    },
+    'serverless-offline-sqs': {
+      autoCreate: true,
+      apiVersion: '2012-11-05',
+      endpoint: 'http://0.0.0.0:9324',
+      region: 'us-east-1',
+      accessKeyId: 'root',
+      secretAccessKey: 'root',
+      skipCacheInvalidation: false,
+    },
+    customDomain: {
+      domainName: `${customSettings.domain.name}`,
+      stage: customSettings.domain.stage,
+      basePath: customSettings.domain.basePath,
+      certificateName: `*.${customSettings.domain.name}`,
+      createRoute53Record: true,
+      createRoute53IPv6Record: true,
+      endpointType: 'regional',
+      securityPolicy: 'tls_1_2',
+      apiType: 'http',
+      autoDomain: false,
+    },
+  };
+};

--- a/services/public-api/serverless.ts
+++ b/services/public-api/serverless.ts
@@ -7,6 +7,7 @@ const serverlessConfiguration: Serverless = {
   service: serviceName,
   frameworkVersion: '3',
   plugins: [
+    // 'serverless-domain-manager',
     'serverless-esbuild',
     'serverless-analyze-bundle-plugin',
     'serverless-offline',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4053,6 +4053,22 @@ aws-sdk@^2.1136.0, aws-sdk@^2.1174.0, aws-sdk@^2.970.0:
     uuid "8.0.0"
     xml2js "0.4.19"
 
+aws-sdk@^2.1186.0:
+  version "2.1189.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1189.0.tgz#8dd6b48dd7896642af8e2f86e026932a28e380d5"
+  integrity sha512-EqluXSo8XAR086nF9UAtPYwUm82ZIRqg8OmHBRQyftcrD1Z0pqMmiuvacXoEAJ/4UU8KKafbpYarxx8rH/pZjQ==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.16.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    util "^0.12.4"
+    uuid "8.0.0"
+    xml2js "0.4.19"
+
 axios@^0.21.1:
   version "0.21.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
@@ -9630,6 +9646,13 @@ serverless-analyze-bundle-plugin@^1.2.0:
   dependencies:
     "@babel/runtime" "^7.18.6"
     check-node-version "^4.2.1"
+
+serverless-domain-manager@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/serverless-domain-manager/-/serverless-domain-manager-6.0.4.tgz#4791a2153f89083987d0bbad644c32651f67351a"
+  integrity sha512-G2SuRl4zt6XQ7ZxZR65PJu50mRyPA48V6O/9NHUJYCn5Lw7/DUPki3SaEJMx4kyXFbdzulfm8zeY3MgWY4t7Kg==
+  dependencies:
+    aws-sdk "^2.1186.0"
 
 serverless-esbuild@^1.32.5:
   version "1.32.5"


### PR DESCRIPTION
Closes #106 

- Add serverless-domain-manager
- Add helper for configuring the settings
- Show where to add the plugin in public-api

Current Debates:
- Should this even be included in this template?
- Is the override too restrictive? See docs for all different config options: https://github.com/amplify-education/serverless-domain-manager#installing
- Does it need better documentation or examples? For instance, each service could theoretically be deployed to a subdomain _but_ that defeats the purposes of the pattern of a single service for public interaction.